### PR TITLE
feat: Use uv Python build metadata for version lookups

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: audit.base
 Title: Base package for Posit Checks
-Version: 0.6.28
+Version: 0.6.29
 Authors@R:
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: Base package for sharing classes between posit audit

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# audit.base 0.6.29 _2026-07-07_
+  * feat: Use uv's Python build metadata to determine latest Python versions
+  * chore: Software bump
+
 # audit.base 0.6.28 _2026-07-06_
   * docs: Document `check_timezone()`
   * fix: Coerce `cve` column to numeric in `get_posit_versions()`

--- a/R/get_latest_versions_remote.R
+++ b/R/get_latest_versions_remote.R
@@ -2,7 +2,7 @@
 # -/blob/5c584fced32a6fc8fd7b25b3ea78f6fb7a8bd7ca/template/ansible/scripts/versions.sh
 get_latest_versions_remote = function() {
   r = get_latest_versions_from_posit("r")
-  py = get_latest_versions_from_posit("python")
+  py = get_uv_python_versions()
   # Drop latest to get all releases
   q = jsonlite::read_json(
     "https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest"
@@ -16,6 +16,7 @@ get_latest_versions_remote = function() {
     "1.5.57",
     "1.6.43",
     "1.7.34",
+    "1.8.27",
     stringr::str_remove(q$name, "^v")
   )
 

--- a/R/get_uv_python_versions.R
+++ b/R/get_uv_python_versions.R
@@ -1,0 +1,42 @@
+get_uv_python_versions = function() {
+  url = "https://raw.githubusercontent.com/astral-sh/uv/main/crates/uv-python/download-metadata.json"
+  raw_json = jsonlite::fromJSON(url, simplifyVector = FALSE)
+
+  if (length(raw_json) == 0) {
+    warning("Fetched Python JSON is empty -- check the URL/branch/tag.")
+    return(NULL)
+  }
+
+  versions = purrr::imap_dfr(raw_json, function(entry, key) {
+    tibble::tibble(
+      key = key,
+      name = entry$name %||% NA_character_,
+      major = entry$major %||% NA_integer_,
+      minor = entry$minor %||% NA_integer_,
+      patch = entry$patch %||% NA_integer_,
+      prerelease = entry$prerelease %||% NA_character_,
+      version = paste(
+        entry$major %||% NA,
+        entry$minor %||% NA,
+        entry$patch %||% NA,
+        sep = "."
+      ) |>
+        paste0(entry$prerelease %||% ""),
+      os = entry$os %||% NA_character_,
+      libc = entry$libc %||% NA_character_,
+      arch_family = entry$arch$family %||% NA_character_,
+    )
+  })
+  versions |>
+    dplyr::filter(
+      !nzchar(.data$prerelease),
+      .data$os == "linux",
+      .data$libc == "gnu",
+      .data$arch_family == "x86_64"
+    ) |>
+    dplyr::distinct(.data$major, .data$minor, .data$patch, .data$version) |>
+    dplyr::group_by(.data$major, .data$minor) |>
+    dplyr::filter(.data$patch == max(.data$patch)) |>
+    dplyr::arrange(-.data$major, -.data$minor) |>
+    dplyr::pull(.data$version)
+}

--- a/inst/extdata/versions/software.csv
+++ b/inst/extdata/versions/software.csv
@@ -1,10 +1,13 @@
 software,version
-python,3.13.9
-python,3.12.12
-python,3.11.14
-python,3.10.19
+python,3.14.6
+python,3.13.14
+python,3.12.13
+python,3.11.15
+python,3.10.20
 python,3.9.25
+python,3.8.20
 quarto,1.9.38
+quarto,1.8.27
 quarto,1.7.34
 quarto,1.6.43
 quarto,1.5.57


### PR DESCRIPTION
## Summary
- Switch `get_latest_versions_remote()` to source Python versions from uv's build metadata (`get_uv_python_versions()`) instead of Posit's versions API.
- Add `1.8.27` to the hardcoded Quarto release list and dedupe the Quarto entries in the software snapshot.
- Refresh `inst/extdata/versions/software.csv` and bump version to 0.6.29 with a NEWS entry.

## Test plan
- [x] `devtools::test()` — 54 passed, 0 failed (18 pre-existing network-related warnings, unrelated to this change)